### PR TITLE
Add .gch, .exe in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 .prettierignore
+
+# Precompiled Headers
+*.gch
+
+# Executables
+*.exe


### PR DESCRIPTION
컴파일시 자동 생성되는 파일 .gitignore에 추가

- precompiled header
.gch
- excutable files
.exe